### PR TITLE
Rewrite Mammoth reduction to avoid bug, add some comments, fix broken data path

### DIFF
--- a/tutorials/mammoth/2-flatten-mammoth.ipynb
+++ b/tutorials/mammoth/2-flatten-mammoth.ipynb
@@ -55,9 +55,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install \"3lc[umap,pacmap]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import tlc\n",
     "\n",
-    "table = tlc.Table.from_names(table_name=\"mammoth-10k\", dataset_name=\"Mammoth\", project_name=\"Table Writer Examples\")"
+    "# Load the table from the previous example. It contains a single column containing the 3D points.\n",
+    "table = tlc.Table.from_names(table_name=\"mammoth-10k\", dataset_name=\"Mammoth\", project_name=\"Table Writer Examples\")\n",
+    "\n",
+    "table.columns"
    ]
   },
   {
@@ -66,27 +78,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reduced_umap = tlc.reduce_embeddings_multiple_parameters(\n",
-    "    table=table,\n",
-    "    method=\"umap\",\n",
-    "    parameter_sets=[\n",
-    "        {\n",
-    "            \"n_components\": 2,\n",
-    "            \"n_neighbors\": 15,\n",
-    "            \"min_dist\": 0.1,\n",
-    "            \"metric\": \"euclidean\",\n",
-    "        },\n",
-    "        {\n",
-    "            \"n_components\": 2,\n",
-    "            \"n_neighbors\": 50,\n",
-    "            \"min_dist\": 0.5,\n",
-    "            \"metric\": \"manhattan\",\n",
-    "            \"retain_source_embedding_column\": True,\n",
-    "        },\n",
-    "    ],\n",
-    ")\n",
+    "umap_params_1 = {\n",
+    "    \"n_components\": 2,     # Project the data to 2 dimensions\n",
+    "    \"n_neighbors\": 15,     # Local connectivity, fewer neighbors create more local clusters\n",
+    "    \"min_dist\": 0.1,       # Minimum distance between points in the embedding space, preserves more local structure\n",
+    "    \"metric\": \"euclidean\", # Use Euclidean distance to measure similarity\n",
+    "    \"retain_source_embedding_column\": True,\n",
+    "    \"source_embedding_column\": \"points\",\n",
+    "}\n",
     "\n",
-    "print(f\"Reduced UMAP: {reduced_umap}\")"
+    "reduced_umap_1 = tlc.reduce_embeddings(table, \"umap\", **umap_params_1)\n",
+    "\n",
+    "umap_params_2 = {\n",
+    "    \"n_components\": 2,     # Project the data to 2 dimensions\n",
+    "    \"n_neighbors\": 50,     # Local connectivity, more neighbors create more global structure\n",
+    "    \"min_dist\": 0.5,       # Minimum distance between points in the embedding space, allows more spread out embedding\n",
+    "    \"metric\": \"manhattan\", # Use Manhattan distance to measure similarity\n",
+    "    \"retain_source_embedding_column\": True,\n",
+    "    \"source_embedding_column\": \"points\",\n",
+    "}\n",
+    "\n",
+    "reduced_umap_2 = tlc.reduce_embeddings(table, \"umap\", **umap_params_2)"
    ]
   },
   {
@@ -95,18 +107,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reduced_table = tlc.Table.from_url(reduced_umap)\n",
+    "pacmap_param_1 = {\n",
+    "    \"n_components\": 2,  # Project the data to 2 dimensions\n",
+    "    \"n_neighbors\": 10,  # Number of neighbors to consider, fewer neighbors emphasize local structure\n",
+    "    \"MN_ratio\": 0.5,    # Ratio of mid-near pairs, balancing between local and global structure\n",
+    "    \"FP_ratio\": 2.0,    # Ratio of far pairs, emphasizing the global structure more\n",
+    "    \"retain_source_embedding_column\": True,\n",
+    "    \"source_embedding_column\": \"points\",\n",
+    "}\n",
     "\n",
-    "reduced_pacmap = tlc.reduce_embeddings_multiple_parameters(\n",
-    "    table=reduced_table,\n",
-    "    method=\"pacmap\",\n",
-    "    parameter_sets=[\n",
-    "        {\"n_components\": 2, \"n_neighbors\": 10, \"MN_ratio\": 0.5, \"FP_ratio\": 2.0},\n",
-    "        {\"n_components\": 2, \"n_neighbors\": 30, \"MN_ratio\": 1.0, \"FP_ratio\": 1.0, \"retain_source_embedding_column\": True},\n",
-    "    ],\n",
+    "reduced_pacmap_1 = tlc.reduce_embeddings(\n",
+    "    reduced_umap_2,\n",
+    "    \"pacmap\",\n",
+    "    **pacmap_param_1,\n",
     ")\n",
     "\n",
-    "print(f\"Reduced PACMAP: {reduced_pacmap}\")"
+    "pacmap_param_2 = {\n",
+    "    \"n_components\": 2,  # Project the data to 2 dimensions\n",
+    "    \"n_neighbors\": 30,  # Number of neighbors to consider, more neighbors emphasize global structure\n",
+    "    \"MN_ratio\": 1.0,    # Ratio of mid-near pairs, equal balance between local and global structure\n",
+    "    \"FP_ratio\": 1.0,    # Ratio of far pairs, standard emphasis on global structure\n",
+    "    \"retain_source_embedding_column\": True,\n",
+    "    \"source_embedding_column\": \"points\",\n",
+    "}\n",
+    "\n",
+    "reduced_pacmap_2 = tlc.reduce_embeddings(\n",
+    "    reduced_pacmap_1,\n",
+    "    \"pacmap\",\n",
+    "    **pacmap_param_2,\n",
+    ")"
    ]
   }
  ],
@@ -126,7 +155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/write-augmented-samples.ipynb
+++ b/tutorials/write-augmented-samples.ipynb
@@ -62,7 +62,7 @@
     "TABLE_NAME = \"coco-128\"\n",
     "RUN_NAME = \"register-augmented-samples\"\n",
     "RUN_DESCRIPTION = \"Inspecting augmentations on COCO-128\"\n",
-    "TEST_DATA_PATH = \"./data\"\n",
+    "TEST_DATA_PATH = \"../data\"\n",
     "BATCH_SIZE = 32\n",
     "EPOCHS = 10\n",
     "\n",
@@ -112,6 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
     "from torchvision.datasets import ImageFolder\n",
     "\n",
     "augmentations = T.Compose(\n",
@@ -132,6 +133,8 @@
     "    ]\n",
     ")\n",
     "\n",
+    "\n",
+    "# TEST_DATA_PATH = Path(TEST_DATA_PATH).absolute().as_posix()\n",
     "coco_128 = ImageFolder(TEST_DATA_PATH + \"/coco128\", transform=augmentations)"
    ]
   },
@@ -241,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There is a bug in the `reduce_embeddings_multiple_parameters` method, so rewrote the flatten-mammoth notebook to avoid it. This also makes it more clear what is going on. 

Fix broken data path in augmentation notebook.