### PR TITLE
Remove hugging face `evaluate` library from segmentation example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/.venv*/
+*/.venv*/
 .env
 transient_data

--- a/tutorials/huggingface-segmentation-example.ipynb
+++ b/tutorials/huggingface-segmentation-example.ipynb
@@ -54,14 +54,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "PROJECT_NAME = \"Hugging Face SegFormer Example\"\n",
     "DATASET_NAME = \"ADE20k_toy_dataset\"\n",
     "TRANSIENT_DATA_PATH = \"../transient_data\"\n",
-    "EPOCHS = 200\n",
+    "EPOCHS = 100\n",
     "BATCH_SIZE = 2\n",
     "DEVICE = \"cuda\"\n",
     "\n",
@@ -70,16 +70,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "%%capture\n",
     "if INSTALL_DEPENDENCIES:\n",
     "    %pip --quiet install 3lc\n",
-    "    %pip --quiet install transformers huggingface_hub evaluate\n",
+    "    %pip --quiet install transformers huggingface_hub\n",
     "    %pip --quiet install torch torchvision\n",
-    "    %pip --quiet install sklearn tqdm"
+    "    %pip --quiet install tqdm"
    ]
   },
   {
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,11 +99,9 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "import evaluate\n",
     "import torch\n",
     "from huggingface_hub import hf_hub_download\n",
     "from PIL import Image\n",
-    "from sklearn.metrics import accuracy_score\n",
     "from torch.utils.data import DataLoader, Dataset\n",
     "from tqdm.notebook import tqdm\n",
     "from transformers import SegformerImageProcessor\n",
@@ -120,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,15 +523,6 @@
     "\n",
     "train_dataloader = DataLoader(train_table, batch_size=BATCH_SIZE, sampler=sampler)\n",
     "valid_dataloader = DataLoader(val_table, batch_size=BATCH_SIZE)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "metric = evaluate.load(\"mean_iou\")"
    ]
   },
   {
@@ -551,6 +540,8 @@
     "model.train()\n",
     "for epoch in range(EPOCHS):  # loop over the dataset multiple times\n",
     "    print(\"Epoch:\", epoch)\n",
+    "    agg_loss = 0.0\n",
+    "    seen_samples = 0\n",
     "    for idx, batch in enumerate(tqdm(train_dataloader)):\n",
     "        # get the inputs;\n",
     "        pixel_values = batch[\"pixel_values\"].to(DEVICE)\n",
@@ -563,6 +554,9 @@
     "        outputs = model(pixel_values=pixel_values, labels=labels)\n",
     "        loss, logits = outputs.loss, outputs.logits\n",
     "\n",
+    "        agg_loss += loss.item() * pixel_values.shape[0]\n",
+    "        seen_samples += pixel_values.shape[0]\n",
+    "\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
     "\n",
@@ -573,31 +567,11 @@
     "            )\n",
     "            predicted = upsampled_logits.argmax(dim=1)\n",
     "\n",
-    "            # note that the metric expects predictions + labels as numpy arrays\n",
-    "            metric.add_batch(predictions=predicted.detach().cpu().numpy(), references=labels.detach().cpu().numpy())\n",
-    "\n",
-    "        # let's print loss and metrics every 100 batches\n",
-    "        if idx % 100 == 0:\n",
-    "            # currently using _compute instead of compute\n",
-    "            # see this issue for more info: https://github.com/huggingface/evaluate/pull/328#issuecomment-1286866576\n",
-    "            metrics = metric._compute(\n",
-    "                predictions=predicted.cpu(),\n",
-    "                references=labels.cpu(),\n",
-    "                num_labels=len(id2label),\n",
-    "                ignore_index=255,\n",
-    "                reduce_labels=False,  # we've already reduced the labels ourselves\n",
-    "            )\n",
-    "\n",
-    "            print(\"Loss:\", loss.item())\n",
-    "            print(\"Mean_iou:\", metrics[\"mean_iou\"])\n",
-    "            print(\"Mean accuracy:\", metrics[\"mean_accuracy\"])\n",
-    "\n",
-    "            # Log aggregated metrics directly to the active Run\n",
-    "            tlc.log({\n",
-    "                \"loss\": loss.item(),\n",
-    "                \"mean_iou\": metrics[\"mean_iou\"],\n",
-    "                \"mean_accuracy\": metrics[\"mean_accuracy\"]\n",
-    "            })\n",
+    "    # Log aggregated metrics directly to the active Run\n",
+    "    tlc.log({\n",
+    "        \"epoch\": epoch,\n",
+    "        \"running_train_loss\": loss.item() / seen_samples,\n",
+    "    })\n",
     "\n",
     "    if epoch % 50 == 0 and epoch != 0:\n",
     "        collect_metrics(epoch)"
@@ -652,7 +626,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/huggingface-segmentation-example.ipynb
+++ b/tutorials/huggingface-segmentation-example.ipynb
@@ -61,7 +61,7 @@
     "PROJECT_NAME = \"Hugging Face SegFormer Example\"\n",
     "DATASET_NAME = \"ADE20k_toy_dataset\"\n",
     "TRANSIENT_DATA_PATH = \"../transient_data\"\n",
-    "EPOCHS = 100\n",
+    "EPOCHS = 200\n",
     "BATCH_SIZE = 2\n",
     "DEVICE = \"cuda\"\n",
     "\n",

--- a/tutorials/huggingface-segmentation-example.ipynb
+++ b/tutorials/huggingface-segmentation-example.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
The `mean_iou` metric from `evaluate` uses an inordinate amount of disk space (or memory with `keep_in_memory=True`). This PR removes it for the time being, but keeps the computation of average loss from the training loop.