### PR TITLE
Add progress bar to image metrics computation and read images in a storage-agnostic way

### DIFF
--- a/src/tlc_tools/add_columns_to_table.py
+++ b/src/tlc_tools/add_columns_to_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import typing
 from collections import defaultdict
 from typing import Any, Callable
@@ -71,7 +72,7 @@ def add_columns_to_table(
         for column_name, column_value in row.items():
             if input_schemas[column_name].sample_type == tlc.PILImage.sample_type:
                 image_url = tlc.Url(column_value).to_absolute(table.url)
-                column_value = Image.open(image_url.to_str())
+                column_value = Image.open(io.BytesIO(image_url.read()))
 
             output_row[column_name] = column_value
 
@@ -94,7 +95,7 @@ def add_image_metrics_to_table(
 ) -> tlc.Table:
     """"""
     new_columns = defaultdict(list)
-    for row in table.table_rows:
+    for row in tqdm(table.table_rows, desc="Computing image metrics", total=len(table)):
         image_path = tlc.Url(row[image_column_name]).to_absolute().to_str()
         metrics = compute_image_metrics(image_path, image_metrics)
         for column_name, value in metrics.items():

--- a/src/tlc_tools/metrics.py
+++ b/src/tlc_tools/metrics.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import io
 from collections import defaultdict
 from typing import Literal, get_args
 
 import cv2
 import numpy as np
+import tlc
 from PIL import Image, ImageStat
 from scipy.spatial.distance import pdist, squareform
 from sklearn.cluster import KMeans
@@ -147,7 +149,7 @@ IMAGE_METRICS = Literal[
 ]
 
 
-def compute_image_metrics(image_path: str, metrics: list[IMAGE_METRICS] | None = None) -> dict[str, float]:
+def compute_image_metrics(image_path: str | tlc.Url, metrics: list[IMAGE_METRICS] | None = None) -> dict[str, float]:
     """Return a dict of image metrics for the given image path."""
 
     if not metrics:
@@ -155,7 +157,11 @@ def compute_image_metrics(image_path: str, metrics: list[IMAGE_METRICS] | None =
 
     computed_metrics = {}
 
-    image = Image.open(image_path)
+    # Convert str to Url if needed
+    url = tlc.Url(image_path) if isinstance(image_path, str) else image_path
+
+    # Open image from URL using BytesIO
+    image = Image.open(io.BytesIO(url.read()))
     width, height = image.size
 
     if "width" in metrics:

--- a/tutorials/2-modify-tables/add-embeddings.ipynb
+++ b/tutorials/2-modify-tables/add-embeddings.ipynb
@@ -31,6 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import io\n",
+    "\n",
     "import tlc\n",
     "from PIL import Image\n",
     "\n",
@@ -72,7 +74,12 @@
    "outputs": [],
    "source": [
     "# Map the table to return only the image column as a PIL.Image:\n",
-    "table.map(lambda x: Image.open(x[\"image\"]).convert(\"RGB\"))\n",
+    "def convert_image(sample):\n",
+    "    image_bytes = io.BytesIO(tlc.Url(sample[\"image\"]).read())\n",
+    "    return Image.open(image_bytes).convert(\"RGB\")\n",
+    "\n",
+    "\n",
+    "table.map(convert_image)\n",
     "\n",
     "# Add embeddings to the table:\n",
     "extended_table = add_embeddings_to_table(table)"


### PR DESCRIPTION
The example notebooks should work with images regardless of whether they are stored on s3/gcs, or local.
The example notebooks should provide useful progress bars.

+ Changed some instances of how image URLs are sent to PIL.Image.open().
+ Added some tqdm progress bars where deemed necessary.