### PR TITLE
Refactor transforms in crop-finetuning notebook

### DIFF
--- a/tutorials/5-advanced-examples/bb-embeddings/1-fine-tune-on-crops.ipynb
+++ b/tutorials/5-advanced-examples/bb-embeddings/1-fine-tune-on-crops.ipynb
@@ -181,7 +181,8 @@
    "outputs": [],
    "source": [
     "# Define the transformations to be applied to the images\n",
-    "common_transforms = transforms.Compose(\n",
+    "\n",
+    "val_transforms = transforms.Compose(\n",
     "    [\n",
     "        transforms.Lambda(lambda img: img.convert(\"RGB\")),\n",
     "        transforms.Resize((224, 224)),\n",
@@ -192,10 +193,13 @@
     "\n",
     "train_transforms = transforms.Compose(\n",
     "    [\n",
-    "        transforms.ColorJitter(brightness=0.3, contrast=0.3, saturation=0.2, hue=0.3),\n",
+    "        transforms.Lambda(lambda img: img.convert(\"RGB\")),\n",
     "        transforms.RandomRotation(degrees=10),\n",
+    "        transforms.Resize((224, 224)),\n",
     "        transforms.RandomHorizontalFlip(),\n",
-    "        *common_transforms.transforms,\n",
+    "        transforms.ColorJitter(brightness=0.3, contrast=0.3, saturation=0.2, hue=0.3),\n",
+    "        transforms.ToTensor(),\n",
+    "        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),\n",
     "    ]\n",
     ")\n",
     "\n",
@@ -213,10 +217,22 @@
     "\n",
     "val_dataset = BBCropDataset(\n",
     "    val_table,\n",
-    "    transform=common_transforms,\n",
+    "    transform=val_transforms,\n",
     "    add_background=False,\n",
     "    is_train=False,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot samples\n",
+    "\n",
+    "Let's plot some samples from our training and validation datasets to visually\n",
+    "inspect how our transform pipeline is working. For training samples, we should\n",
+    "see data augmentation effects like color jitter, rotation and flips. For\n",
+    "validation samples, we should only see the basic resizing and normalization."
    ]
   },
   {
@@ -225,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def write_image_grid(images, labels, rows: int, cols: int, title: str):\n",
+    "def plot_samples(images, labels, rows: int, cols: int, title: str):\n",
     "    assert len(images) == len(labels), \"Number of images and labels must be the same.\"\n",
     "    assert len(images) <= rows * cols, \"Not enough space in the grid for all images.\"\n",
     "\n",
@@ -252,9 +268,9 @@
     "    for ax in axes[len(images) :]:\n",
     "        ax.axis(\"off\")\n",
     "\n",
-    "    # Save the figure\n",
+    "    # Show the figure\n",
     "    plt.tight_layout()\n",
-    "    plt.suptitle(title)\n",
+    "    plt.suptitle(title, fontsize=16, y=1.02)\n",
     "    plt.show()"
    ]
   },
@@ -264,14 +280,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_images = []\n",
-    "train_labels = []\n",
-    "for i in range(4 * 3):\n",
-    "    image, label = train_dataset[i]\n",
-    "    train_images.append(image)\n",
-    "    train_labels.append(label_map.get(label.item(), \"Background\"))\n",
+    "def get_sample_images_and_labels(dataset, label_map, n_samples, default_label=\"Background\"):\n",
+    "    \"\"\"Get sample images and labels from a dataset for visualization.\"\"\"\n",
+    "    images = []\n",
+    "    labels = []\n",
+    "    for i in range(n_samples):\n",
+    "        image, label = dataset[i]\n",
+    "        images.append(image)\n",
+    "        label_value = label.item()\n",
+    "        labels.append(label_map.get(label_value, default_label))\n",
+    "    return images, labels\n",
     "\n",
-    "write_image_grid(train_images, train_labels, 4, 3, \"Training Images\")"
+    "\n",
+    "# Number of samples to visualize\n",
+    "n_rows = 4\n",
+    "n_cols = 3\n",
+    "n_samples = n_rows * n_cols\n",
+    "\n",
+    "# Get training and validation samples\n",
+    "train_images, train_labels = get_sample_images_and_labels(train_dataset, label_map, n_samples)\n",
+    "val_images, val_labels = get_sample_images_and_labels(val_dataset, label_map, n_samples, default_label=None)"
    ]
   },
   {
@@ -280,14 +308,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "val_images = []\n",
-    "val_labels = []\n",
-    "for i in range(4 * 3):\n",
-    "    image, label = val_dataset[i]\n",
-    "    val_images.append(image)\n",
-    "    val_labels.append(label_map[label.item()])\n",
-    "\n",
-    "write_image_grid(val_images, val_labels, 4, 3, \"Validation Images\")"
+    "plot_samples(train_images, train_labels, n_rows, n_cols, \"Training Images\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_samples(val_images, val_labels, n_rows, n_cols, \"Validation Images\")"
    ]
   },
   {


### PR DESCRIPTION
The transforms in the notebook fine-tune-on-crops.ipyunb were sub-optimal, re-wrote train and val transforms explicitly in the optimal order: spatial transforms first, then color transforms, then convert to tensor before finally normalizing.