### PR TITLE
Add .filename to PIL images written in add_columns_to_table tool

### DIFF
--- a/src/tlc_tools/add_columns_to_table.py
+++ b/src/tlc_tools/add_columns_to_table.py
@@ -73,6 +73,7 @@ def add_columns_to_table(
             if input_schemas[column_name].sample_type == tlc.PILImage.sample_type:
                 image_url = tlc.Url(column_value).to_absolute(table.url)
                 column_value = Image.open(io.BytesIO(image_url.read()))
+                column_value._tlc_url = image_url.to_str()
 
             output_row[column_name] = column_value
 

--- a/src/tlc_tools/add_columns_to_table.py
+++ b/src/tlc_tools/add_columns_to_table.py
@@ -73,7 +73,7 @@ def add_columns_to_table(
             if input_schemas[column_name].sample_type == tlc.PILImage.sample_type:
                 image_url = tlc.Url(column_value).to_absolute(table.url)
                 column_value = Image.open(io.BytesIO(image_url.read()))
-                column_value._tlc_url = image_url.to_str()
+                column_value.filename = image_url.to_str()
 
             output_row[column_name] = column_value
 

--- a/src/tlc_tools/embeddings.py
+++ b/src/tlc_tools/embeddings.py
@@ -23,13 +23,15 @@ def temporary_table_map(table: tlc.Table, map_fn: Callable | None = None):
     :param table: The table to temporarily map
     :param map_fn: Optional mapping function to apply
     """
+    if map_fn is None:
+        yield table
+        return
+
     try:
-        if map_fn is not None:
-            table.map(map_fn)
+        table.map(map_fn)
         yield table
     finally:
-        if map_fn is not None:
-            table._map_functions.pop()
+        table._map_functions.pop()
 
 
 def add_embeddings_to_table(


### PR DESCRIPTION
We need to convert values to "sample view" when adding input values to a derived table (using TableWriter).
This is unfortunate, but currently a limitation. When we use a BytesIO buffer to load the image data before opening it using Image.open, the filename information is lost, causing the TableWriter to attempt to write a copy of the image, and failing because of lack of bulk data prefix. This simple fix adds back the _tlc_url to the sample, allowing us to avoid file copying.