### PR TITLE
Fix notebook CI stragglers: imdb dataset id and explicit timm cache_dir

### DIFF
--- a/tutorials/3-training-and-metrics/dimensionality-reduction-example.ipynb
+++ b/tutorials/3-training-and-metrics/dimensionality-reduction-example.ipynb
@@ -38,7 +38,6 @@
     "TIMM_MODEL_NAME = \"resnet18\"\n",
     "METHOD = \"pacmap\"\n",
     "BATCH_SIZE = 32\n",
-    "DOWNLOAD_PATH = \"../../transient_data\"\n",
     "NUM_COMPONENTS = 2\n",
     "INSTALL_DEPENDENCIES = True"
    ]
@@ -75,8 +74,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pathlib import Path\n",
-    "\n",
     "import timm\n",
     "import tlc\n",
     "from torchvision.transforms import Compose, Normalize, Resize, ToTensor\n",
@@ -117,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = timm.create_model(TIMM_MODEL_NAME, pretrained=True, num_classes=0, cache_dir=Path(DOWNLOAD_PATH) / \"models\")\n",
+    "model = timm.create_model(TIMM_MODEL_NAME, pretrained=True, num_classes=0)\n",
     "model = model.to(infer_torch_device())"
    ]
   },

--- a/tutorials/3-training-and-metrics/huggingface-imdb-finetuning.ipynb
+++ b/tutorials/3-training-and-metrics/huggingface-imdb-finetuning.ipynb
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "train_dataset = tlc.Table.from_hugging_face_hub(\n",
-    "    \"imdb\",\n",
+    "    \"stanfordnlp/imdb\",\n",
     "    split=\"train\",\n",
     "    project_name=PROJECT_NAME,\n",
     "    dataset_name=TRAIN_DATASET_NAME,\n",
@@ -175,7 +175,7 @@
     ")\n",
     "\n",
     "eval_dataset = tlc.Table.from_hugging_face_hub(\n",
-    "    \"imdb\",\n",
+    "    \"stanfordnlp/imdb\",\n",
     "    split=\"test\",\n",
     "    project_name=PROJECT_NAME,\n",
     "    dataset_name=EVAL_DATASET_NAME,\n",
@@ -199,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_dataset_hf = datasets.load_dataset(\"imdb\", split=\"train\")\n",
+    "train_dataset_hf = datasets.load_dataset(\"stanfordnlp/imdb\", split=\"train\")\n",
     "train_dataset_hf[0]"
    ]
   },


### PR DESCRIPTION
## What

Companion to tlc-monorepo PR 6796 ([AB#16940](https://dev.azure.com/3lc-ai/03cc99a8-2998-4d34-85d1-008f291d1f3d/_workitems/edit/16940) — EFS artifact caching for notebook CI).

- **`huggingface-imdb-finetuning.ipynb`**: `"imdb"` → `"stanfordnlp/imdb"` (3 places: `Table.from_hugging_face_hub` ×2 and `datasets.load_dataset`). Current `datasets` versions reject bare canonical dataset names, so the notebook is broken for fresh installs regardless of CI.
- **`dimensionality-reduction-example.ipynb`**: drop the explicit `cache_dir=Path(DOWNLOAD_PATH) / "models"` argument from `timm.create_model` (plus the now-unused `DOWNLOAD_PATH` parameter and `Path` import). Model caching is handled by the standard `HF_HOME` mechanism — one less instrumentation-looking artifact in the notebook, and it allows retiring the legacy `data/models/` prefix in the public examples bucket.

## Verification

Validated by tlc-monorepo on-demand run 132732 (full test-mode notebook suite against this branch): 39/39 notebooks passed with zero model downloads from the internet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)