### PR TITLE
Notebook dependencies (17667) + external-user experience pass (17668)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
   rev: 0.8.1
   hooks:
     - id: nbstripout
-      exclude: ^example-notebooks/
 
 - repo: local
   hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,12 @@
 
 This repository contains examples, tutorials, and CLI tools for the **3LC** data platform. It provides:
 
-- ~61 Jupyter notebooks demonstrating 3LC usage across ML workflows
+- ~63 Jupyter notebooks demonstrating 3LC usage across ML workflows
 - A Python package (`tlc_tools`) with CLI tools extending 3LC functionality
 - Sample datasets for tutorials
 - Integrations with PyTorch, HuggingFace, Detectron2, Ultralytics YOLO, PyTorch Lightning, and Super-Gradients
 
-**Package:** `3lc_tools` v2.19 | **License:** Apache 2.0 | **Python:** 3.9 - 3.12
+**Package:** `3lc_tools` v3.0 | **License:** Apache 2.0 | **Python:** 3.10 - 3.13
 
 ## Repository Structure
 
@@ -26,6 +26,7 @@ This repository contains examples, tutorials, and CLI tools for the **3LC** data
 │   ├── split.py             # Data splitting strategies
 │   └── ...
 ├── tutorials/               # Jupyter notebooks organized by category
+│   ├── notebooks.yaml       # Single source of truth for notebook metadata (see below)
 │   ├── 1-create-tables/     # 21 notebooks: table creation from various sources
 │   ├── 2-modify-tables/     # 13 notebooks: adding metrics, embeddings, splitting
 │   ├── 3-training-and-metrics/ # 25 notebooks: training with various frameworks
@@ -35,7 +36,7 @@ This repository contains examples, tutorials, and CLI tools for the **3LC** data
 │   ├── cli/                 # CLI command tests
 │   └── tools/               # Tool-specific tests (alias, instance metrics, metric jumps)
 ├── data/                    # Sample datasets (COCO, balloons, cats-and-dogs, etc.)
-└── utils/                   # Image normalization utilities for tutorial images
+└── utils/                   # Maintainer tooling: notebooks_metadata.py + image normalization
 ```
 
 ## Development Setup
@@ -90,7 +91,18 @@ pre-commit run --all-files      # Run all hooks manually
 
 Hooks configured:
 - **ruff** (v0.11.4): lint with `--fix` + format
-- **nbstripout** (v0.8.1): strip notebook outputs (excludes `example-notebooks/`)
+- **nbstripout** (v0.8.1): strip notebook outputs
+
+### Notebook Metadata
+
+`tutorials/notebooks.yaml` is the single source of truth for notebook metadata. Derived fields (title, blurb, tags, thumbnail, project_meta) are extracted from the notebooks themselves; curated fields (include_in_docs/tests/public_examples, params, depends_on) are hand-maintained and preserved across syncs.
+
+```bash
+python -m utils.notebooks_metadata sync    # Regenerate derived fields after editing notebooks
+python -m utils.notebooks_metadata check   # Fail if derived fields drift (run in CI)
+```
+
+After adding, renaming, or editing the first cell or parameters cell of any notebook, run `sync` and commit the updated `notebooks.yaml`.
 
 ### CLI Tool
 
@@ -105,7 +117,7 @@ Hooks configured:
 - **Target Python:** 3.9
 - **Linting rules:** B (bugbear), E (pycodestyle), F (pyflakes), UP (pyupgrade), SIM (simplify), I (isort)
 - **Import sorting:** `tlc` is classified as known third-party
-- **Ruff scope:** `src/tlc_tools/**/*.py`, `tests/**/*.py`, `pyproject.toml` (excludes `example-notebooks/`)
+- **Ruff scope:** `src/tlc_tools/**/*.py`, `tests/**/*.py`, `pyproject.toml`
 - **Type hints:** Used in source code; avoided in notebooks unless using 3LC-specific types
 
 ### 3LC Code Annotations
@@ -143,19 +155,21 @@ GitHub Actions workflow (`.github/workflows/lint.yml`) runs on PRs to `main`:
 2. MyPy type checking
 3. Pytest test suite
 
-Environment: Ubuntu latest, Python 3.9 (from `.python-version-ci`), uv 0.7.13.
+Environment: Ubuntu latest, Python 3.10 (from `.python-version-ci`), uv 0.7.13.
+
+Notebook execution CI lives in the 3LC monorepo, which fetches the `tutorials/` tree and consumes `tutorials/notebooks.yaml` directly (it does not import `utils/notebooks_metadata.py`).
 
 ## Key Dependencies
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| 3lc | >=2.19.0, <3.0.0 | Core 3LC platform |
+| 3lc | >=3.0.0, <4.0.0 | Core 3LC platform |
 | opencv-python | >=4.10, <5.0 | Computer vision ops |
 | scikit-learn | >=1.5.2, <2.0 | ML utilities |
 | fpsample | >=0.3.3, <1.0 | Furthest point sampling |
 | ruff | >=0.9.0, <1.0 | Linting & formatting |
 | mypy | >=1.13, <2.0 | Type checking |
-| pytest | >=8.3.3, <9.0 | Testing |
+| pytest | >=9.0.3, <10.0 | Testing |
 | papermill | >=2.6.0, <3.0 | Notebook execution |
 
 ## Testing Patterns
@@ -171,4 +185,5 @@ Environment: Ubuntu latest, Python 3.9 (from `.python-version-ci`), uv 0.7.13.
 - The `ultralytics` dependency points to a custom 3LC fork: `git+https://github.com/3lc-ai/ultralytics`
 - The `pandaset` dependency uses a specific git source: `git+https://github.com/scaleapi/pandaset-devkit.git`
 - Build system uses **Hatchling** with wheel packages from `src/tlc_tools`
-- The `example-notebooks/` directory is excluded from both ruff linting and nbstripout
+- `tutorials/notebooks.yaml` and `utils/` are maintainer-facing; external users running notebooks never need them
+- Several notebooks depend on 3LC Tables created by other notebooks (tracked via `depends_on` in `notebooks.yaml`); when editing a notebook's project/dataset/table names, check for downstream consumers

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Follow these steps to set up the repository and environment for running the note
     pip install -e .[all]
     ```
 
-    To install the dev dependencies for formatting code and running tests, use:
+    To install the development dependencies for formatting code and running tests (maintainers and contributors only), use [uv](https://docs.astral.sh/uv/):
 
     ```bash
-    pip install -e .[dev]
+    uv sync --all-extras --dev
     ```
 
 4. Running the Notebooks
@@ -92,6 +92,24 @@ Follow these steps to set up the repository and environment for running the note
 5. Get Started
 
     From your notebook interface, open any notebook from the repository to get started. Be sure to select the correct kernel/environment where the packages have been installed.
+
+## Running the Notebooks
+
+The notebooks are designed to run top-to-bottom on a fresh clone with no setup beyond the installation steps above. A few things are useful to know:
+
++ **Data**: Most notebooks either use small datasets bundled in the `data/` folder or download what they need at runtime (to the `transient_data/` folder, which is ignored by git). A few notebooks require extra steps, and say so in their introduction:
+  + Kaggle-hosted datasets require [Kaggle API credentials](https://www.kaggle.com/docs/api) (`~/.kaggle/kaggle.json`).
+  + Some datasets (e.g. FHIBE, LIACi) must be downloaded manually due to licensing; the notebook explains where to get them.
++ **Prerequisite notebooks**: Some notebooks build on 3LC Tables created by earlier notebooks (for example, training notebooks reuse tables from the `1-create-tables` tutorials). When a notebook has a prerequisite, it is linked in the notebook's introduction — run the linked notebook first.
++ **Hardware**: Training notebooks run fastest with a GPU (CUDA or Apple Silicon). The Detectron2 notebooks require a CUDA GPU and a Linux-like environment.
+
+### Repository Layout
+
++ `tutorials/` — the main collection, organized as `1-create-tables`, `2-modify-tables`, `3-training-and-metrics`, and `4-end-to-end-examples`.
++ `examples/` — additional standalone examples, including custom sample types and integrations.
++ `data/` — small datasets bundled for the tutorials.
++ `src/tlc_tools/` — the `tlc_tools` Python package and CLI installed by `pip install -e .`.
++ `tutorials/notebooks.yaml` and `utils/` — **maintainer-facing infrastructure** used by the 3LC team's documentation and CI pipelines. You can ignore these entirely when running the notebooks.
 
 ## CLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,9 @@ lightning = [
 pandaset = [
     "pandaset",
 ]
+all = [
+    "3lc_tools[sam,huggingface,umap,pacmap,timm,kaggle,ultralytics,lightning,pandaset]",
+]
 
 [dependency-groups]
 dev = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -4,10 +4,6 @@ include = [
     "tests/**/*.py",
 ]
 
-exclude = [
-    "example-notebooks/",
-]
-
 line-length = 120
 indent-width = 4
 target-version = "py39"

--- a/tutorials/2-modify-tables/add-instance-embeddings/1-train-crop-model.ipynb
+++ b/tutorials/2-modify-tables/add-instance-embeddings/1-train-crop-model.ipynb
@@ -113,7 +113,7 @@
    "source": [
     "## Load input Table\n",
     "\n",
-    "We will reuse the table created in the notebook [create-table-from-coco-detection.ipynb](../../1-create-tables/object%20detection/create-table-from-coco-detection.ipynb)."
+    "We will reuse the table created in the notebook [create-table-from-coco-segmentation.ipynb](../../1-create-tables/instance-segmentation/create-table-from-coco-segmentation.ipynb)."
    ]
   },
   {

--- a/tutorials/2-modify-tables/split-tables.ipynb
+++ b/tutorials/2-modify-tables/split-tables.ipynb
@@ -197,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We first need a table with an embeddings column."
+    "We first need a table with an embeddings column. We will reuse the `reduced_0000` table created at the end of the [add-embeddings.ipynb](./add-embeddings.ipynb) notebook, so make sure you have run that notebook first."
    ]
   },
   {

--- a/tutorials/3-training-and-metrics/supergradients-detection-yolonas-training.ipynb
+++ b/tutorials/3-training-and-metrics/supergradients-detection-yolonas-training.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "PROJECT_NAME = \"3LC Tutorials\"\n",
+    "PROJECT_NAME = \"3LC Tutorials - COCO128\"\n",
     "DATASET_NAME = \"COCO128\"\n",
     "YOLONAS_MODEL = \"YOLO_NAS_S\"  # Options: YOLO_NAS_S, YOLO_NAS_M, YOLO_NAS_L\n",
     "BATCH_SIZE = 4\n",

--- a/tutorials/notebooks.yaml
+++ b/tutorials/notebooks.yaml
@@ -1,11 +1,14 @@
 # Single source of truth for example notebook metadata.
 #
+# NOTE: This file is maintainer-facing infrastructure used by the 3LC team's docs/CI
+# pipelines. If you are here to run the notebooks, you can ignore it entirely.
+#
 # DERIVED fields (title, blurb, tags, thumbnail, project_meta) are extracted from the
 # notebooks themselves -- do NOT edit them by hand. Regenerate with:
 #     python -m utils.notebooks_metadata sync
 # CI (`... check`) fails if they drift from notebook content.
 #
-# CURATED fields (include_in_docs/tests/public_examples, params, depends_on) are
+# CURATED fields (include_in_docs/tests/public_examples, params, depends_on, creates) are
 # hand-maintained here and preserved across sync.
 
 - path: 1-create-tables/3d/pandaset/load-pandaset.ipynb
@@ -26,6 +29,7 @@
     MAX_FRAMES: {test: 10, publish: null}
     MAX_SEQUENCES: {test: 1, publish: 5}
   depends_on: []
+  creates: []
 - path: 1-create-tables/3d/write-mammoth-table.ipynb
   title: Create a Table from 3D points
   blurb: Create a 3LC Table directly from row data containing 3D point cloud information using the Mammoth dataset for 3D object analysis.
@@ -42,6 +46,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-custom-table.ipynb
   title: Create Custom Table
   blurb: Create a custom 3LC Table containing multiple data types with defined schemas and dummy data for demonstration purposes.
@@ -58,6 +63,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-fhibe-table.ipynb
   title: Load FHIBE Dataset
   blurb: This notebook loads the Sony AI's "Fair Human-Centric Image Benchmark" dataset as a 3LC Table, including keypoints, segmentation, bounding boxes, as well as rich subject metadata.
@@ -75,6 +81,7 @@
   params:
     MAX_SAMPLES: {test: 10, publish: 2000}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-semantic-segmentation-table.ipynb
   title: Create Semantic Segmentation Table
   blurb: Create a 3LC Table for semantic segmentation tasks using paired images and grayscale mask files from the ADE20k dataset.
@@ -91,6 +98,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-table-from-image-folder.ipynb
   title: Create Table from Image Folder
   blurb: Create a 3LC Table from a folder structure containing images organized by class labels for image classification tasks.
@@ -107,6 +115,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-table-from-torch-dataset.ipynb
   title: Create Table from PyTorch Dataset
   blurb: Convert a PyTorch Dataset into a 3LC Table using the built-in conversion method.
@@ -124,6 +133,7 @@
   params:
     MAX_SAMPLES: {test: 1000, publish: null}
   depends_on: []
+  creates: []
 - path: 1-create-tables/create-table-from-videos.ipynb
   title: Create a Table from video frames
   blurb: Create a 3LC Table by extracting individual frames from video files in the UCF11 action recognition dataset.
@@ -140,6 +150,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/instance-segmentation/create-custom-instance-segmentation-table.ipynb
   title: Create Custom Instance Segmentation Table
   blurb: Create a 3LC Table from custom RLE annotations using the Sartorius cell instance segmentation dataset with hundreds of cell instances per image.
@@ -157,6 +168,7 @@
   params:
     MAX_IMAGES: {test: 10, publish: null}
   depends_on: []
+  creates: []
 - path: 1-create-tables/instance-segmentation/create-instance-segmentations-from-image-masks.ipynb
   title: Convert Semantic to Instance Segmentation
   blurb: 'Convert a semantic segmentation dataset into the instance segmentation format used by 3LC, using the simplest possible mapping: every semantic class becomes a single "instance".'
@@ -173,6 +185,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/instance-segmentation/create-instance-segmentations-from-masks.ipynb
   title: Import instance segmentation dataset from multiple image masks
   blurb: In this tutorial, we will import the LIACi (Lifecycle Inspection, Analysis and Condition information) Segmentation Dataset for Underwater Ship Inspections, introduced in [this](https://ieeexplore.i...
@@ -184,6 +197,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/instance-segmentation/create-table-from-coco-segmentation.ipynb
   title: Create Table from COCO Instance Segmentation
   blurb: Create a 3LC Table from COCO-format dataset containing images with instance segmentation annotations for object detection and segmentation tasks.
@@ -200,6 +214,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/instance-segmentation/create-table-from-yolo-segmentation.ipynb
   title: Create Table from YOLO Instance Segmentation
   blurb: Create a 3LC Table from YOLO-format dataset with polygon-based instance segmentation annotations for modern object detection pipelines.
@@ -216,6 +231,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/keypoints/create-custom-keypoints-table.ipynb
   title: Create Custom Keypoints Table
   blurb: Create a 3LC keypoints table from the Animal-Pose dataset with custom schema definitions for pose estimation tasks.
@@ -232,6 +248,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/keypoints/create-table-from-coco-keypoints.ipynb
   title: Create Table from COCO Keypoints
   blurb: Create a 3LC keypoints table from COCO-format annotations for human pose estimation and keypoint detection tasks.
@@ -248,6 +265,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/keypoints/create-table-from-yolo-keypoints.ipynb
   title: Create Table from YOLO Keypoints
   blurb: Create a 3LC keypoints table from YOLO-format dataset with normalized keypoint coordinates for efficient pose estimation workflows.
@@ -264,6 +282,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/obbs/create-custom-obb-table.ipynb
   title: Create Custom Oriented Bounding Box Table
   blurb: Create a 3LC Table with oriented bounding boxes using the HRSC2016-MS maritime ship detection dataset for rotated object detection.
@@ -280,6 +299,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/obbs/create-table-from-yolo-obb.ipynb
   title: Create Table from YOLO - Oriented Bounding Boxes (OBB)
   blurb: This notebook demonstrates how to create a 3LC Table from a YOLO-format dataset for **oriented bounding box detection** tasks.
@@ -296,6 +316,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/object detection/create-custom-bb-table.ipynb
   title: Create Custom Bounding Box Table
   blurb: Build a 3LC Table from scratch with custom bounding box annotations and schema definitions for specialized object detection scenarios.
@@ -312,6 +333,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/object detection/create-table-from-coco-detection.ipynb
   title: Create Table from COCO Object Detection
   blurb: Create a 3LC Table from COCO-format dataset containing images with bounding box annotations for standard object detection tasks.
@@ -328,6 +350,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 1-create-tables/object detection/create-table-from-yolo-detection.ipynb
   title: Create Table from YOLO Object Detection
   blurb: Create a 3LC Table from YOLO-format dataset with normalized bounding box annotations for efficient object detection workflows.
@@ -344,6 +367,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 2-modify-tables/1-weight-coreset.ipynb
   title: Weighted Table Subset Selection
   blurb: This notebook demonstrates how to apply zero weights to a subset of table rows for selective data processing.
@@ -360,7 +384,8 @@
   include_in_public_examples: true
   params:
     CORESET_SIZE: {test: 1, publish: 0.01}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-torch-dataset.ipynb]
+  creates: []
 - path: 2-modify-tables/add-classification-metrics.ipynb
   title: Add uniqueness metrics to Table
   blurb: This notebook computes the global image metrics "uniqueness" and "diversity" for each image in a dataset containing images and labels.
@@ -376,7 +401,8 @@
   include_in_tests: true
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [2-modify-tables/1-weight-coreset.ipynb]
+  creates: []
 - path: 2-modify-tables/add-embeddings.ipynb
   title: Add image embeddings to a Table
   blurb: In this example we will extend an existing table with embeddings computed from a pre-trained model.
@@ -392,7 +418,8 @@
   include_in_tests: true
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/object detection/create-table-from-coco-detection.ipynb]
+  creates: []
 - path: 2-modify-tables/add-image-metrics.ipynb
   title: Add image metrics to a Table
   blurb: In this example we will extend a Table containing images with new columns containing common image metrics (sharpness, contrast, etc.).
@@ -408,7 +435,8 @@
   include_in_tests: true
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/object detection/create-table-from-coco-detection.ipynb]
+  creates: []
 - path: 2-modify-tables/add-instance-embeddings/1-train-crop-model.ipynb
   title: Train a instance classifier on a 3LC Table
   blurb: In this tutorial, we will fine-tune a classifier using instances (segmentations or bounding boxes) from a 3LC `Table`.
@@ -426,7 +454,8 @@
   params:
     EPOCHS: {test: 1, publish: 5}
     EFFICIENTNET_MODEL_NAME: {test: efficientnet_b0, publish: efficientnet_b2}
-  depends_on: []
+  depends_on: [1-create-tables/instance-segmentation/create-table-from-coco-segmentation.ipynb]
+  creates: []
 - path: 2-modify-tables/add-instance-embeddings/2-add-instance-metrics.ipynb
   title: Collect and reduce classifier embeddings
   blurb: In this tutorial, we will use an existing classifier model to generate per-instance embeddings for a COCO-style object detection dataset. We will then reduce these embeddings to 3D using PaCMAP.
@@ -443,7 +472,8 @@
   include_in_public_examples: true
   params:
     EFFICIENTNET_MODEL_NAME: {test: efficientnet_b0, publish: efficientnet_b2}
-  depends_on: []
+  depends_on: [1-create-tables/instance-segmentation/create-table-from-coco-segmentation.ipynb, 2-modify-tables/add-instance-embeddings/1-train-crop-model.ipynb]
+  creates: []
 - path: 2-modify-tables/add-new-data-and-split.ipynb
   title: Add new data to dataset with splits
   blurb: Add new data and re-split a dataset.
@@ -460,6 +490,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 2-modify-tables/add-new-data.ipynb
   title: Add new data to existing Table lineage
   blurb: Adding new data to an existing dataset is a common task, as more data is collected and we want to leverage it to improve the model. This notebook demonstrates how to add new data to an existing 3LC...
@@ -475,7 +506,8 @@
   include_in_tests: true
   include_in_public_examples: false
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-image-folder.ipynb]
+  creates: []
 - path: 2-modify-tables/autosegment-image-column.ipynb
   title: Auto-segment images using SAM
   blurb: This notebook creates a 3LC Table with auto-generated segmentation masks from SAM using grid-based point prompting.
@@ -492,6 +524,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 2-modify-tables/compute-per-bb-metrics.ipynb
   title: Per Bounding Box Luminosity Calculation
   blurb: This notebook demonstrates how to calculate the luminosity of images and their bounding boxes and add them as columns to a Table.
@@ -508,6 +541,7 @@
   include_in_public_examples: true
   params: {}
   depends_on: []
+  creates: []
 - path: 2-modify-tables/dimensionality-reduction-toy-example.ipynb
   title: Compare dimensionality reduction methods
   blurb: This notebook demonstrates how to perform dimensionality reduction on a column in a `tlc.Table` using two different dimensionality reduction algorithms, `pacmap` and `umap`.
@@ -523,7 +557,8 @@
   include_in_tests: true
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/3d/write-mammoth-table.ipynb]
+  creates: []
 - path: 2-modify-tables/split-tables.ipynb
   title: Split tables
   blurb: Datasets are commonly divided into splits for training, validation and testing. This notebook shows how a single Table can be divided into two or more such splits, with different strategies for how...
@@ -539,7 +574,8 @@
   include_in_tests: true
   include_in_public_examples: false
   params: {}
-  depends_on: []
+  depends_on: [2-modify-tables/add-embeddings.ipynb]
+  creates: []
 - path: 2-modify-tables/transform-bbs-to-segs.ipynb
   title: Convert bounding boxes to instance segmentation masks using SAM
   blurb: This notebook creates a derived Table with an added column containing instance segmentation masks generated by the SAM model using the Table's existing bounding boxes as prompts.
@@ -555,7 +591,8 @@
   include_in_tests: true
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/object detection/create-table-from-coco-detection.ipynb]
+  creates: []
 - path: 3-training-and-metrics/detectron2-balloons-detection-finetuning.ipynb
   title: Fine-tune a object detection model using Detectron2
   blurb: This notebook shows how to collect bounding box metrics while training a model using Detectron2.
@@ -574,6 +611,7 @@
     MAX_ITERATIONS: {test: 100, publish: 400}
     DETECTRON2_MODEL_CONFIG: {test: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml, publish: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/detectron2-balloons-segmentation-finetuning.ipynb
   title: Fine-tune a instance segmentation model using Detectron2
   blurb: This notebook shows how to collect instance segmentation metrics while training a model using Detectron2.
@@ -592,6 +630,7 @@
     MAX_ITERATIONS: {test: 100, publish: 400}
     DETECTRON2_MODEL_CONFIG: {test: COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml, publish: COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/detectron2-coco128-detection-collection.ipynb
   title: Collect Bounding Boxes using Detectron2
   blurb: This notebook collects object detection metrics using the Detectron2 library and the COCO128 subset.
@@ -609,6 +648,7 @@
   params:
     DETECTRON2_MODEL_CONFIG: {test: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml, publish: COCO-Detection/faster_rcnn_R_50_FPN_3x.yaml}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/detectron2-coco128-segmentation-collection.ipynb
   title: Collect instance segmentation metrics using Detectron2
   blurb: This notebook collects instance segmentation metrics using the Detectron2 library and the COCO128 subset.
@@ -626,6 +666,7 @@
   params:
     DETECTRON2_MODEL_CONFIG: {test: COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml, publish: COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/dimensionality-reduction-example.ipynb
   title: Apply dimensionality reduction to multiple Tables
   blurb: This example shows how to use the "producer-consumer" pattern for re-using dimensionality reduction models across different tables.
@@ -642,7 +683,8 @@
   include_in_public_examples: true
   params:
     TIMM_MODEL_NAME: {test: resnet18, publish: resnet18}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-torch-dataset.ipynb, 2-modify-tables/1-weight-coreset.ipynb]
+  creates: []
 - path: 3-training-and-metrics/huggingface-ade20k-segformer-finetuning.ipynb
   title: Fine-tune Hugging Face SegFormer on a custom dataset
   blurb: This tutorial covers metrics collection on a custom semantic segmentation dataset using `3lc` and training using 🤗 `transformers`.
@@ -661,6 +703,7 @@
     EPOCHS: {test: 100, publish: 200}
     SEGFORMER_MODEL_ID: {test: nvidia/mit-b0, publish: nvidia/mit-b0}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/huggingface-cifar100-collect-embeddings.ipynb
   title: Hugging Face CIFAR-100 Embeddings Example
   blurb: In this notebook we will see how to use a pre-trained Vision Transformers (ViT) model to collect embeddings on the CIFAR-100 dataset.
@@ -678,6 +721,7 @@
   params:
     VIT_MODEL_ID: {test: google/vit-base-patch16-224, publish: google/vit-base-patch16-224}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/huggingface-coco128-segformer-collection.ipynb
   title: Collect Instance Segmentation Metrics from Pretrained Model
   blurb: In this example, we will collect predicted instance segmentation masks from a pretrained model from the Hugging Face Hub.
@@ -695,6 +739,7 @@
   params:
     MASK2FORMER_MODEL_ID: {test: facebook/mask2former-swin-tiny-coco-instance, publish: facebook/mask2former-swin-base-coco-instance}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/huggingface-imdb-finetuning.ipynb
   title: 🤗 and 3LC example on the IMDb dataset
   blurb: This notebook demonstrates fine-tuning a pretrained DistilBERT model from `transformers` on the `IMDb` dataset, using the 3LC integrations with `Trainer` and `datasets` from Hugging Face. 3LC metri...
@@ -713,6 +758,7 @@
     EPOCHS: {test: 1, publish: 5}
     IMDB_MODEL_ID: {test: distilbert-base-uncased, publish: bert-base-uncased}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/huggingface-mrcp-bert-finetuning.ipynb
   title: Fine-tuning a model with the 🤗 3LC Trainer
   blurb: This notebook demonstrates how to use the 3LC Hugging Face Trainer integration to fine-tune a BERT model (bert-base-uncased).
@@ -730,6 +776,7 @@
   params:
     EPOCHS: {test: 1, publish: 5}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/lightning-balloons-segformer-training.ipynb
   title: Fine-tuning a SegFormer model with Pytorch Lightning
   blurb: This notebook fine-tunes a SegFormer model for semantic segmentation using PyTorch Lightning.
@@ -748,6 +795,7 @@
     EPOCHS: {test: 1, publish: 10}
     SEGFORMER_MODEL_ID: {test: nvidia/mit-b0, publish: nvidia/mit-b2}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/lightning-cifar10-resnet-training.ipynb
   title: Training a classifier using PyTorch Lightning
   blurb: This notebook trains a classifier on CIFAR-10 using PyTorch Lightning.
@@ -765,6 +813,7 @@
   params:
     EPOCHS: {test: 1, publish: 5}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/pytorch-augmentation-explorer.ipynb
   title: Register Augmented Samples From a Training Loop
   blurb: In this notebook, we will demonstrate how to register augmented samples from a training loop as 3LC metrics.
@@ -781,6 +830,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/pytorch-cifar10-collect-metrics.ipynb
   title: Collect metrics using a pre-trained model
   blurb: This notebook demonstrates how to use a pre-trained model to collect metrics on a dataset.
@@ -796,7 +846,8 @@
   include_in_tests: true
   include_in_public_examples: false
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-torch-dataset.ipynb, 2-modify-tables/1-weight-coreset.ipynb]
+  creates: []
 - path: 3-training-and-metrics/pytorch-cifar10-resnet-training.ipynb
   title: PyTorch 3LC CIFAR-10 Sample Notebook
   blurb: This notebook demonstrates fine-tuning a pretrained ResNet-18 model on the CIFAR-10 dataset using PyTorch and 3LC. We run the fine-tuning process for 5 epochs. During training, both classification ...
@@ -815,6 +866,7 @@
     EPOCHS: {test: 1, publish: 5}
     TIMM_MODEL_NAME: {test: resnet18, publish: resnet18}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/pytorch-cifar10-train-autoencoder.ipynb
   title: Train autoencoder for embedding extraction
   blurb: This notebook showcases more ways of working with metrics and embeddings in 3LC. It is mostly meant as a demonstration of how to collect embeddings and image metrics from a manually trained model.
@@ -832,7 +884,8 @@
   params:
     EPOCHS: {test: 1, publish: 5}
     AUTOENCODER_BACKBONE: {test: resnet50, publish: resnet101}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-torch-dataset.ipynb, 2-modify-tables/1-weight-coreset.ipynb]
+  creates: []
 - path: 3-training-and-metrics/pytorch-fashion-mnist-resnet-training.ipynb
   title: PyTorch 3LC Fashion-MNIST Sample Notebook
   blurb: This notebook is fundamentally similar to the MNIST notebook, but it uses the slightly more interesting FashionMNIST dataset.
@@ -850,6 +903,7 @@
   params:
     EPOCHS: {test: 1, publish: 5}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/pytorch-mnist-resnet-training.ipynb
   title: PyTorch 3LC MNIST Sample Notebook
   blurb: This notebook demonstrates the training of a Convolutional Neural Network (CNN) on the MNIST dataset using PyTorch and 3LC. The built-in MNIST dataset for training and validation is wrapped in a Ta...
@@ -867,6 +921,7 @@
   params:
     EPOCHS: {test: 1, publish: 5}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/sam-coco128-collect-embeddings.ipynb
   title: Collect SAM image embeddings
   blurb: In this example, we will show how to create a Run containing embeddings extracted from SAM for a set of images.
@@ -882,7 +937,8 @@
   include_in_tests: false
   include_in_public_examples: true
   params: {}
-  depends_on: []
+  depends_on: [1-create-tables/object detection/create-table-from-coco-detection.ipynb]
+  creates: []
 - path: 3-training-and-metrics/supergradients-animalpose-yolonas-training.ipynb
   title: Train a YOLO-NAS model for pose estimation with SuperGradients
   blurb: This tutorial trains a SuperGradients YOLO-NAS model for pose estimation the AnimalPose dataset.
@@ -901,14 +957,15 @@
     MAX_EPOCHS: {test: 1, publish: 10}
     NUM_WORKERS: {test: 8, publish: 8}
     MODEL_NAME: {test: yolo_nas_pose_n, publish: yolo_nas_pose_m}
-  depends_on: []
+  depends_on: [1-create-tables/keypoints/create-custom-keypoints-table.ipynb]
+  creates: []
 - path: 3-training-and-metrics/supergradients-detection-yolonas-training.ipynb
   title: Train Yolo-NAS model with 3LC Metrics Collection
   blurb: This notebook shows how to train a Yolo-NAS detection model with 3LC Metrics Collection on an Object Detection 3LC `Table`.
   tags: [supergradients, training, object-detection]
   thumbnail: ''
   project_meta:
-    project_name: 3LC Tutorials
+    project_name: 3LC Tutorials - COCO128
     dataset_name: COCO128
     run_name: null
     table_name: null
@@ -920,7 +977,8 @@
     MAX_EPOCHS: {test: 1, publish: 10}
     NUM_WORKERS: {test: 8, publish: 8}
     YOLONAS_MODEL: {test: YOLO_NAS_S, publish: YOLO_NAS_L}
-  depends_on: []
+  depends_on: [1-create-tables/object detection/create-table-from-coco-detection.ipynb]
+  creates: []
 - path: 3-training-and-metrics/ultralytics-animalpose-yolo11-pose-training.ipynb
   title: Train a YOLO model for pose estimation on a custom keypoints dataset
   blurb: This notebook trains a YOLO model for pose estimation on the AnimalPose dataset.
@@ -939,7 +997,8 @@
     EPOCHS: {test: 1, publish: 10}
     NUM_WORKERS: {test: 8, publish: 8}
     MODEL_NAME: {test: yolo11n-pose.pt, publish: yolo11m-pose.pt}
-  depends_on: []
+  depends_on: [1-create-tables/keypoints/create-custom-keypoints-table.ipynb]
+  creates: []
 - path: 3-training-and-metrics/ultralytics-cell-segmentation-yolo11-seg.ipynb
   title: Train a YOLO segmentation model with 3LC metrics collection
   blurb: This notebook shows how to train a YOLO segmentation model with 3LC metrics collection on a YOLO-compatible 3LC `Table`.
@@ -959,6 +1018,7 @@
     NUM_WORKERS: {test: 8, publish: 8}
     MODEL_NAME: {test: yolo11n-seg.pt, publish: yolo11m-seg.pt}
   depends_on: []
+  creates: []
 - path: 3-training-and-metrics/ultralytics-cifar10-yolo11-cls-training.ipynb
   title: Train a YOLO classifier with 3LC metrics collection
   blurb: Train a YOLO classifer using existing tables.
@@ -976,7 +1036,8 @@
   params:
     EPOCHS: {test: 1, publish: 5}
     MODEL_NAME: {test: yolov8n-cls.pt, publish: yolov8m-cls.pt}
-  depends_on: []
+  depends_on: [1-create-tables/create-table-from-torch-dataset.ipynb, 2-modify-tables/1-weight-coreset.ipynb]
+  creates: []
 - path: 3-training-and-metrics/ultralytics-hrsc-2016-yolo-obb-training.ipynb
   title: Train a YOLO model for object detection with oriented bounding boxes
   blurb: This notebook trains a YOLO model for object detection with oriented bounding boxes on the HRSC2016-MS dataset.
@@ -996,6 +1057,7 @@
     NUM_WORKERS: {test: 8, publish: 8}
     MODEL_NAME: {test: yolo11n-obb.pt, publish: yolo11m-obb.pt}
   depends_on: []
+  creates: []
 - path: 4-end-to-end-examples/deep-fish.ipynb
   title: Scaling an Instance Segmentation Dataset with Active Labeling in 3LC
   blurb: How we turned 310 labeled fish into tens of thousands - all in a day's work.
@@ -1007,6 +1069,7 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []
 - path: 4-end-to-end-examples/hard-hat.ipynb
   title: Improving models by fixing object detection labels
   blurb: Label quality is one of the major factors that affects your model's performance. 3LC provides valuable insights into your label quality and singles out problematic labels. By fixing the label error...
@@ -1018,3 +1081,4 @@
   include_in_public_examples: false
   params: {}
   depends_on: []
+  creates: []

--- a/utils/notebooks_metadata.py
+++ b/utils/notebooks_metadata.py
@@ -42,6 +42,7 @@ CURATED_DEFAULTS: dict[str, Any] = {
     "include_in_public_examples": False,
     "params": {},
     "depends_on": [],
+    "creates": [],
 }
 
 # Canonical key order within a single notebook entry (derived first, then curated).
@@ -53,6 +54,7 @@ ENTRY_KEY_ORDER = [
     "include_in_public_examples",
     "params",
     "depends_on",
+    "creates",
 ]
 
 DASHBOARD_URL = "https://dashboard.3lc.ai"
@@ -301,12 +303,15 @@ _NotebooksDumper.add_representer(_FlowMap, _represent_flow_map)
 HEADER = """\
 # Single source of truth for example notebook metadata.
 #
+# NOTE: This file is maintainer-facing infrastructure used by the 3LC team's docs/CI
+# pipelines. If you are here to run the notebooks, you can ignore it entirely.
+#
 # DERIVED fields (title, blurb, tags, thumbnail, project_meta) are extracted from the
 # notebooks themselves -- do NOT edit them by hand. Regenerate with:
 #     python -m utils.notebooks_metadata sync
 # CI (`... check`) fails if they drift from notebook content.
 #
-# CURATED fields (include_in_docs/tests/public_examples, params, depends_on) are
+# CURATED fields (include_in_docs/tests/public_examples, params, depends_on, creates) are
 # hand-maintained here and preserved across sync.
 """
 
@@ -322,6 +327,9 @@ def _ordered_entry(entry: dict[str, Any]) -> dict[str, Any]:
             out[key] = _FlowSeq(value)
         elif key == "params":
             out[key] = {pname: _FlowMap(pval) if isinstance(pval, dict) else pval for pname, pval in value.items()}
+        elif key == "creates":
+            # A list of {project, dataset, table} table contracts; render each inline.
+            out[key] = [_FlowMap(c) if isinstance(c, dict) else c for c in value]
         else:
             out[key] = value
     return out
@@ -378,6 +386,77 @@ def sync(tutorials_dir: Path, yaml_path: Path) -> list[dict[str, Any]]:
     return entries
 
 
+def dependency_problems(stored: list[dict[str, Any]]) -> list[str]:
+    """Validate curated dependency metadata in ``stored`` notebook entries.
+
+    Checks that every ``depends_on`` target is a known notebook (no self-references), that the
+    dependency graph is acyclic, and that each ``creates`` entry is a well-formed table contract.
+
+    Args:
+        stored: Notebook entries as loaded from ``notebooks.yaml``.
+
+    Returns:
+        A list of human-readable problems; empty when the dependency metadata is valid.
+
+    """
+    problems: list[str] = []
+    by_path = {e["path"]: e for e in stored if isinstance(e, dict) and "path" in e}
+    known = set(by_path)
+
+    # depends_on: targets must be known notebooks; self-references are not allowed.
+    graph: dict[str, list[str]] = {}
+    for path, entry in by_path.items():
+        deps = entry.get("depends_on") or []
+        if not isinstance(deps, list):
+            problems.append(f"{path}: 'depends_on' must be a list, got {type(deps).__name__}")
+            deps = []
+        resolved: list[str] = []
+        for dep in deps:
+            if dep == path:
+                problems.append(f"{path}: depends on itself")
+            elif dep not in known:
+                problems.append(f"{path}: depends_on unknown notebook '{dep}'")
+            else:
+                resolved.append(dep)
+        graph[path] = resolved
+
+    # Acyclicity via Kahn's algorithm: edge dep -> dependent.
+    dependents: dict[str, list[str]] = {n: [] for n in graph}
+    indegree: dict[str, int] = {n: 0 for n in graph}
+    for node, deps in graph.items():
+        for dep in deps:
+            dependents[dep].append(node)
+            indegree[node] += 1
+    queue = [n for n in graph if indegree[n] == 0]
+    processed = 0
+    while queue:
+        node = queue.pop()
+        processed += 1
+        for dependent in dependents[node]:
+            indegree[dependent] -= 1
+            if indegree[dependent] == 0:
+                queue.append(dependent)
+    if processed != len(graph):
+        in_cycle = sorted(n for n in graph if indegree[n] > 0)
+        problems.append(f"dependency cycle among notebooks: {', '.join(in_cycle)}")
+
+    # creates: a list of {project, dataset, table} table contracts.
+    for path, entry in by_path.items():
+        creates = entry.get("creates") or []
+        if not isinstance(creates, list):
+            problems.append(f"{path}: 'creates' must be a list, got {type(creates).__name__}")
+            continue
+        for i, contract in enumerate(creates):
+            if not isinstance(contract, dict):
+                problems.append(f"{path}: creates[{i}] must be a mapping, got {type(contract).__name__}")
+                continue
+            missing = [k for k in ("project", "dataset", "table") if not contract.get(k)]
+            if missing:
+                problems.append(f"{path}: creates[{i}] missing required key(s): {', '.join(missing)}")
+
+    return problems
+
+
 def check(tutorials_dir: Path, yaml_path: Path) -> list[str]:
     """Return a list of human-readable drift problems; empty list means the file is up to date."""
     problems: list[str] = []
@@ -414,6 +493,8 @@ def check(tutorials_dir: Path, yaml_path: Path) -> list[str]:
                     f"    in notebooks.yaml: {existing.get(field)!r}\n"
                     f"    from notebook:     {derived[field]!r}"
                 )
+
+    problems.extend(dependency_problems(stored))
 
     return problems
 

--- a/uv.lock
+++ b/uv.lock
@@ -94,6 +94,22 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "evaluate" },
+    { name = "joblib" },
+    { name = "kaggle" },
+    { name = "kagglehub" },
+    { name = "pacmap" },
+    { name = "pandaset" },
+    { name = "pytorch-lightning" },
+    { name = "segment-anything" },
+    { name = "timm" },
+    { name = "transformers" },
+    { name = "ultralytics" },
+    { name = "umap-learn" },
+]
 huggingface = [
     { name = "accelerate" },
     { name = "datasets" },
@@ -145,6 +161,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "3lc", specifier = ">=3.0.0,<4.0.0", index = "https://pypi.3lc.ai/public/repositories/releases-public" },
+    { name = "3lc-tools", extras = ["sam", "huggingface", "umap", "pacmap", "timm", "kaggle", "ultralytics", "lightning", "pandaset"], marker = "extra == 'all'" },
     { name = "accelerate", marker = "extra == 'huggingface'", specifier = ">=1.8.1" },
     { name = "datasets", marker = "extra == 'huggingface'", specifier = ">=2.17.0" },
     { name = "evaluate", marker = "extra == 'huggingface'", specifier = ">=0.4.1,<1.0.0" },
@@ -167,7 +184,7 @@ requires-dist = [
     { name = "ultralytics", marker = "extra == 'ultralytics'", git = "https://github.com/3lc-ai/ultralytics" },
     { name = "umap-learn", marker = "extra == 'umap'", specifier = ">=0.5.4,<1.0.0" },
 ]
-provides-extras = ["sam", "huggingface", "umap", "pacmap", "timm", "kaggle", "ultralytics", "lightning", "pandaset"]
+provides-extras = ["sam", "huggingface", "umap", "pacmap", "timm", "kaggle", "ultralytics", "lightning", "pandaset", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Two related finalization work items, landing together (same files touched). Companion monorepo PR (consumes these fields in the test runner and docs): https://dev.azure.com/3lc-ai/TLC/_git/tlc-monorepo/pullrequest/6837

## 17667 — Formalize inter-notebook dependencies

- `notebooks.yaml` gains two curated fields: `depends_on` (prerequisite notebook paths) and `creates` (project/dataset/table contracts, currently empty placeholders).
- `depends_on` populated for all ~20 known cross-notebook table dependencies (seeded from the 17668 audit).
- `python -m utils.notebooks_metadata check` now validates dependency metadata: unknown/self references, cycles, malformed `creates` contracts.
- `supergradients-detection-yolonas-training.ipynb` moved to the `3LC Tutorials - COCO128` project so its declared dependency actually resolves.

## 17668 — External-user experience pass

Goal: a fresh clone runs notebooks without encountering or understanding the CI instrumentation.

- **README**: new "Running the Notebooks" section (data policy, credential requirements, prerequisite notebooks, hardware notes) and "Repository Layout" section; `tutorials/notebooks.yaml` + `utils/` explicitly marked maintainer-facing (also noted in the yaml header).
- **Broken install instructions fixed**: `pip install -e .[all]` referenced a nonexistent extra — now defined in `pyproject.toml`; `.[dev]` no longer exists (dev deps are a uv dependency-group) — README now says `uv sync --all-extras --dev`.
- **Dead config removed**: `example-notebooks/` exclusions in `ruff.toml` / `.pre-commit-config.yaml` matched nothing since the directory rename.
- **CLAUDE.md** refreshed post-3.0/post-reorg: versions, Python range, the `notebooks_metadata sync`/`check` workflow, removed stale claims.
- **Notebook doc fixes**: `1-train-crop-model.ipynb` linked the wrong prerequisite notebook; `split-tables.ipynb` had an undocumented dependency on the `reduced_0000` table from `add-embeddings.ipynb`.

The full audit (per-notebook standalone-path findings + `tlc_tools` usage classification) is recorded under work item 17668. Notebooks that cannot run from a fresh clone (FHIBE, LIACi, yolo-obb placeholder, hard-hat, deep-fish) are content follow-ups, intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)