### PR TITLE
Make sure pkg-resources is installed for a couple of notebooks that depend on it

### DIFF
--- a/tutorials/3-training-and-metrics/detectron2-coco128-detection-collection.ipynb
+++ b/tutorials/3-training-and-metrics/detectron2-coco128-detection-collection.ipynb
@@ -73,7 +73,7 @@
     "    %env CC=gcc-11\n",
     "    %env CXX=g++-11\n",
     "    %pip install -q 3lc[pacmap]\n",
-    "    %pip install -q setuptools<82.0.0 wheel ninja\n",
+    "    %pip install -q setuptools standard-pkg-resources wheel ninja\n",
     "    %pip install -q --no-build-isolation git+https://github.com/facebookresearch/detectron2.git\n",
     "    %pip install -q opencv-python\n",
     "    %pip install -q matplotlib"

--- a/tutorials/3-training-and-metrics/detectron2-coco128-detection-collection.ipynb
+++ b/tutorials/3-training-and-metrics/detectron2-coco128-detection-collection.ipynb
@@ -73,7 +73,7 @@
     "    %env CC=gcc-11\n",
     "    %env CXX=g++-11\n",
     "    %pip install -q 3lc[pacmap]\n",
-    "    %pip install -q setuptools wheel ninja\n",
+    "    %pip install -q setuptools<82.0.0 wheel ninja\n",
     "    %pip install -q --no-build-isolation git+https://github.com/facebookresearch/detectron2.git\n",
     "    %pip install -q opencv-python\n",
     "    %pip install -q matplotlib"

--- a/tutorials/3-training-and-metrics/detectron2-coco128-segmentation-collection.ipynb
+++ b/tutorials/3-training-and-metrics/detectron2-coco128-segmentation-collection.ipynb
@@ -74,7 +74,7 @@
     "    #       See https://detectron2.readthedocs.io/en/latest/tutorials/install.html for details.\n",
     "    %env CC=gcc-11\n",
     "    %env CXX=g++-11\n",
-    "    %pip install -q setuptools<82.0.0 wheel ninja\n",
+    "    %pip install -q setuptools standard-pkg-resources wheel ninja\n",
     "    %pip install -q --no-build-isolation git+https://github.com/facebookresearch/detectron2.git\n",
     "    %pip install -q 3lc[pacmap]\n",
     "    %pip install -q opencv-python\n",

--- a/tutorials/3-training-and-metrics/detectron2-coco128-segmentation-collection.ipynb
+++ b/tutorials/3-training-and-metrics/detectron2-coco128-segmentation-collection.ipynb
@@ -74,7 +74,7 @@
     "    #       See https://detectron2.readthedocs.io/en/latest/tutorials/install.html for details.\n",
     "    %env CC=gcc-11\n",
     "    %env CXX=g++-11\n",
-    "    %pip install -q setuptools wheel ninja\n",
+    "    %pip install -q setuptools<82.0.0 wheel ninja\n",
     "    %pip install -q --no-build-isolation git+https://github.com/facebookresearch/detectron2.git\n",
     "    %pip install -q 3lc[pacmap]\n",
     "    %pip install -q opencv-python\n",


### PR DESCRIPTION
pkg-resources is a transitive dependency that is no longer available through other dependencies, so we install a version directly to be used at runtime. 